### PR TITLE
fix: replace passlib with bcrypt and remove user_id/role from token r…

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -57,8 +57,6 @@ async def login(credentials: LoginRequest, db: Session = Depends(get_db)) -> Tok
     return TokenResponse(
         access_token=access_token,
         expires_in=24 * 3600,  # 24 hours in seconds
-        user_id=str(user.id),
-        role=user.role.value,
     )
 
 

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -5,26 +5,21 @@ Security utilities for password hashing and JWT tokens.
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+import bcrypt
 import jwt
-from passlib.context import CryptContext
 
 from app.core.keys import private_key, public_key
 from app.core.settings import settings
 
-# Password hashing
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-
 
 def get_password_hash(password: str) -> str:
     """Hash a password for storing in the database."""
-    hashed: str = pwd_context.hash(password)
-    return hashed
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     """Verify a password against its hash."""
-    result: bool = pwd_context.verify(plain_password, hashed_password)
-    return result
+    return bcrypt.checkpw(plain_password.encode(), hashed_password.encode())
 
 
 def create_access_token(data: dict[str, Any], expires_delta: timedelta | None = None) -> str:

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -22,11 +22,9 @@ class TokenResponse(BaseModel):
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
-                "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
                 "token_type": "bearer",
                 "expires_in": 86400,
-                "user_id": "1",
-                "role": "admin",
             }
         }
     )
@@ -34,8 +32,6 @@ class TokenResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"
     expires_in: int  # Duration in seconds
-    user_id: str
-    role: str
 
 
 class TokenData(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
   "pydantic-settings==2.*",
   "python-json-logger==2.*",
   "prometheus-client==0.*",
-  "passlib[bcrypt]==1.7.*",
+  "bcrypt==4.*",
   "pyjwt==2.*"
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,7 +23,6 @@ cryptography>=42.0
 # Logging
 python-json-logger==2.*
 PyJWT==2.*
-passlib[bcrypt]==1.*
 
 # Monitoring / metrics
 prometheus-client==0.*
@@ -39,7 +38,7 @@ black==24.*
 mypy==1.*
 pylint==3.*
 ruff==0.*
-types-passlib==1.*
+types-bcrypt==0.*
 
 # Security checks
 bandit>=1.7.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -38,7 +38,6 @@ black==24.*
 mypy==1.*
 pylint==3.*
 ruff==0.*
-types-bcrypt==0.*
 
 # Security checks
 bandit>=1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ cryptography>=42.0
 # Logging
 python-json-logger==2.*
 PyJWT==2.*
-passlib[bcrypt]==1.*
 
 # Monitoring / metrics
 prometheus-client==0.*


### PR DESCRIPTION
…esponse

- Replace passlib (unmaintained) with direct bcrypt usage to fix version warning
- Remove user_id and role from TokenResponse (already available in JWT payload)
- Remove passlib from requirements.txt, requirements-dev.txt and pyproject.toml

